### PR TITLE
feat: improved webpack support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,197 @@
-const { loadBinding } = require('@node-rs/helper')
+const { existsSync, readFileSync } = require('fs')
+const { join } = require('path')
 
-/**
- * __dirname means load native addon from current dir
- * 'resvg' means native addon name is `resvg`
- * the first arguments was decided by `napi.name` field in `package.json`
- * the second arguments was decided by `name` field in `package.json`
- * loadBinding helper will load `resvg.[PLATFORM].node` from `__dirname` first
- * If failed to load addon, it will fallback to load from `@resvg/resvgjs-[PLATFORM]`
- */
-module.exports = loadBinding(__dirname, 'resvgjs', '@resvg/resvg-js')
+const { platform, arch } = process
+
+let nativeBinding = null
+let localFileExisted = false
+let isMusl = false
+let loadError = null
+
+switch (platform) {
+  case 'android':
+    if (arch !== 'arm64') {
+      throw new Error(`Unsupported architecture on Android ${arch}`)
+    }
+    localFileExisted = existsSync(join(__dirname, 'resvgjs.android-arm64.node'))
+    try {
+      if (localFileExisted) {
+        nativeBinding = require('./resvgjs.android-arm64.node')
+      } else {
+        nativeBinding = require('@resvg/resvg-js-android-arm64')
+      }
+    } catch (e) {
+      loadError = e
+    }
+    break
+  case 'win32':
+    switch (arch) {
+      case 'x64':
+        localFileExisted = existsSync(join(__dirname, 'resvgjs.win32-x64-msvc.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./resvgjs.win32-x64-msvc.node')
+          } else {
+            nativeBinding = require('@resvg/resvg-js-win32-x64-msvc')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      case 'ia32':
+        localFileExisted = existsSync(join(__dirname, 'resvgjs.win32-ia32-msvc.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./resvgjs.win32-ia32-msvc.node')
+          } else {
+            nativeBinding = require('@resvg/resvg-js-win32-ia32-msvc')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      case 'arm64':
+        localFileExisted = existsSync(join(__dirname, 'resvgjs.win32-arm64-msvc.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./resvgjs.win32-arm64-msvc.node')
+          } else {
+            nativeBinding = require('@resvg/resvg-js-win32-arm64-msvc')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      default:
+        throw new Error(`Unsupported architecture on Windows: ${arch}`)
+    }
+    break
+  case 'darwin':
+    switch (arch) {
+      case 'x64':
+        localFileExisted = existsSync(join(__dirname, 'resvgjs.darwin-x64.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./resvgjs.darwin-x64.node')
+          } else {
+            nativeBinding = require('@resvg/resvg-js-darwin-x64')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      case 'arm64':
+        localFileExisted = existsSync(join(__dirname, 'resvgjs.darwin-arm64.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./resvgjs.darwin-arm64.node')
+          } else {
+            nativeBinding = require('@resvg/resvg-js-darwin-arm64')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      default:
+        throw new Error(`Unsupported architecture on macOS: ${arch}`)
+    }
+    break
+  case 'freebsd':
+    if (arch !== 'x64') {
+      throw new Error(`Unsupported architecture on FreeBSD: ${arch}`)
+    }
+    localFileExisted = existsSync(join(__dirname, 'resvgjs.freebsd-x64.node'))
+    try {
+      if (localFileExisted) {
+        nativeBinding = require('./resvgjs.freebsd-x64.node')
+      } else {
+        nativeBinding = require('@resvg/resvg-js-freebsd-x64')
+      }
+    } catch (e) {
+      loadError = e
+    }
+    break
+  case 'linux':
+    switch (arch) {
+      case 'x64':
+        isMusl = readFileSync('/usr/bin/ldd', 'utf8').includes('musl')
+        if (isMusl) {
+          localFileExisted = existsSync(join(__dirname, 'resvgjs.linux-x64-musl.node'))
+          try {
+            if (localFileExisted) {
+              nativeBinding = require('./resvgjs.linux-x64-musl.node')
+            } else {
+              nativeBinding = require('@resvg/resvg-js-linux-x64-musl')
+            }
+          } catch (e) {
+            loadError = e
+          }
+        } else {
+          localFileExisted = existsSync(join(__dirname, 'resvgjs.linux-x64-gnu.node'))
+          try {
+            if (localFileExisted) {
+              nativeBinding = require('./resvgjs.linux-x64-gnu.node')
+            } else {
+              nativeBinding = require('@resvg/resvg-js-linux-x64-gnu')
+            }
+          } catch (e) {
+            loadError = e
+          }
+        }
+        break
+      case 'arm64':
+        isMusl = readFileSync('/usr/bin/ldd', 'utf8').includes('musl')
+        if (isMusl) {
+          localFileExisted = existsSync(join(__dirname, 'resvgjs.linux-arm64-musl.node'))
+          try {
+            if (localFileExisted) {
+              nativeBinding = require('./resvgjs.linux-arm64-musl.node')
+            } else {
+              nativeBinding = require('@resvg/resvg-js-linux-arm64-musl')
+            }
+          } catch (e) {
+            loadError = e
+          }
+        } else {
+          localFileExisted = existsSync(join(__dirname, 'resvgjs.linux-arm64-gnu.node'))
+          try {
+            if (localFileExisted) {
+              nativeBinding = require('./resvgjs.linux-arm64-gnu.node')
+            } else {
+              nativeBinding = require('@resvg/resvg-js-linux-arm64-gnu')
+            }
+          } catch (e) {
+            loadError = e
+          }
+        }
+        break
+      case 'arm':
+        localFileExisted = existsSync(join(__dirname, 'resvgjs.linux-arm-gnueabihf.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./resvgjs.linux-arm-gnueabihf.node')
+          } else {
+            nativeBinding = require('@resvg/resvg-js-linux-arm-gnueabihf')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      default:
+        throw new Error(`Unsupported architecture on Linux: ${arch}`)
+    }
+    break
+  default:
+    throw new Error(`Unsupported OS: ${platform}, architecture: ${arch}`)
+}
+
+if (!nativeBinding) {
+  if (loadError) {
+    throw loadError
+  }
+  throw new Error(`Failed to load native binding`)
+}
+
+const { render } = nativeBinding
+
+module.exports.render = render

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "format:yaml": "prettier --parser yaml --write './**/*.{yml,yaml}'",
     "lint": "eslint . -c ./.eslintrc.yml './**/*.{ts,tsx,js}'",
     "lint:fix": "eslint . -c ./.eslintrc.yml './**/*.{ts,tsx,js}' --fix",
-    "prepublishOnly": "napi prepublish -t npm",
+    "prepublishOnly": "napi prepublish -t npm && esbuild --minify --outfile=index.js --allow-overwrite index.js",
     "test": "ava",
     "version": "napi version"
   },
@@ -58,6 +58,7 @@
     "ava": "^3.15.0",
     "benny": "^3.7.0",
     "chalk": "^4.1.2",
+    "esbuild": "^0.13.13",
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.2",
@@ -72,9 +73,7 @@
     "svg2img": "^0.9.4",
     "typescript": "^4.4.4"
   },
-  "dependencies": {
-    "@node-rs/helper": "^1.2.1"
-  },
+  "dependencies": {},
   "lint-staged": {
     "*.@(js|ts|tsx)": ["prettier --write", "eslint -c .eslintrc.yml --fix"],
     "*.@(yml|yaml)": ["prettier --parser yaml --write"],


### PR DESCRIPTION
- No more need [@node-rs/helper](https://www.npmjs.com/package/@node-rs/helper) dependency

The `@node-rs/helper` is convenient to load native binary cross platform and cpu arch. But it's not friendly to [`webpack`](https://github.com/webpack/webpack), [`vercel/nft`](https://github.com/vercel/nft) and [`vercel/ncc`](https://github.com/vercel/ncc) because the logic is too dynamic.

Once we upgrade to napi-rs v2, we can automatically generate JS bindings via cli, perfect!