### PR TITLE
test: reduce the file size with the --strip parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "artifacts": "napi artifacts",
     "bench": "node -r @swc-node/register benchmark/bench.ts",
-    "build": "napi build --platform --release --js js-binding.js --dts js-binding.d.ts",
+    "build": "napi build --platform --release --strip --js js-binding.js --dts js-binding.d.ts",
     "build:debug": "napi build --platform --js js-binding.js --dts js-binding.d.ts",
     "format": "run-p format:md format:json format:yaml format:source format:rs",
     "format:md": "prettier --parser markdown --write './**/*.md'",
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@napi-rs/canvas": "^0.1.19",
-    "@napi-rs/cli": "^2.3.0",
+    "@napi-rs/cli": "^2.4.2",
     "@swc-node/register": "^1.4.2",
     "@types/node": "^17.0.1",
     "@types/sharp": "^0.29.5",

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2021-12-23
+nightly

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,10 +473,10 @@
     "@napi-rs/canvas-linux-x64-musl" "0.1.19"
     "@napi-rs/canvas-win32-x64-msvc" "0.1.19"
 
-"@napi-rs/cli@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.3.0.tgz#fb3c9179bf2ff1088f19b235108208acaf051b6f"
-  integrity sha512-sDhyEuUVmgQvm37teoHgJP07+XJy57jfbnDBFVrgOw/+vbr/6yhcn68R3oYxxNLkp3+d57ChVyHxglEFJ6j4Hg==
+"@napi-rs/cli@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.4.2.tgz#89b32c7d8776004bc9617915605aea769339cf6f"
+  integrity sha512-+yCOuPqernvD8BMphbadF87ElaJ0rjanOZrbnauaEdR07YyoalGw3FTk15HHyflIwQKlYd69gkG5EM4WFkICKw==
 
 "@napi-rs/triples@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
Test @napi-rs/cli@2.4.0 add --strip parameter https://github.com/napi-rs/napi-rs/pull/1026

The command this executes when compiling Rust used: 

```
RUSTFLAGS='-C link-arg=-s' cargo build --release
```
See: https://github.com/rust-lang/cargo/issues/3483#issuecomment-431209957