### PR TITLE
feat: support for glibc 2.12

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -48,18 +48,19 @@ jobs:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             architecture: x64
-            docker: |
-              docker pull $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-debian
-              docker tag $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-debian builder
-            build: |
-              docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder yarn build && strip *.node
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine-zig
+            build: >-
+              rustup toolchain install $(cat ./rust-toolchain) &&
+              rustup target add x86_64-unknown-linux-gnu &&
+              yarn build --target x86_64-unknown-linux-gnu --zig --zig-abi-suffix 2.12 &&
+              llvm-strip -x *.node
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
             architecture: x64
-            docker: |
-              docker pull $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-alpine
-              docker tag $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
-            build: docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder yarn build && strip *.node
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            build: |
+              yarn build
+              llvm-strip -x *.node
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
@@ -68,13 +69,14 @@ jobs:
           - host: ubuntu-latest
             architecture: x64
             target: aarch64-unknown-linux-gnu
-            setup: |
-              sudo apt-get update
-              sudo apt-get install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu -y
-            build: |
-              yarn build --target=aarch64-unknown-linux-gnu
-              aarch64-linux-gnu-strip *.node
-          - host: ubuntu-latest
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine-zig
+            build: >-
+              set -e &&
+              rustup toolchain install $(cat ./rust-toolchain) &&
+              rustup target add aarch64-unknown-linux-gnu &&
+              yarn build --target aarch64-unknown-linux-gnu --zig --zig-abi-suffix 2.12 &&
+              llvm-strip -x *.node
+          - host: ubuntu-18.04
             architecture: x64
             target: armv7-unknown-linux-gnueabihf
             setup: |
@@ -107,11 +109,13 @@ jobs:
             architecture: x64
             target: aarch64-unknown-linux-musl
             downloadTarget: aarch64-unknown-linux-musl
-            docker: |
-              docker pull ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-              docker tag ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
-            build: |
-              docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder sh -c "rustup toolchain install $(cat ./rust-toolchain) && rustup target add aarch64-unknown-linux-musl && yarn build --target=aarch64-unknown-linux-musl && /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip *.node"
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            build: >-
+              set -e &&
+              rustup toolchain install $(cat ./rust-toolchain) &&
+              rustup target add aarch64-unknown-linux-musl &&
+              yarn build --target aarch64-unknown-linux-musl &&
+              llvm-strip -x *.node
           - host: windows-latest
             architecture: x64
             target: aarch64-pc-windows-msvc
@@ -122,6 +126,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup node
         uses: actions/setup-node@v2
+        if: ${{ !matrix.settings.docker }}
         with:
           node-version: 16
           check-latest: true
@@ -129,42 +134,49 @@ jobs:
           architecture: ${{ matrix.settings.architecture }}
       - name: Install
         uses: actions-rs/toolchain@v1
+        if: ${{ !matrix.settings.docker }}
         with:
           profile: minimal
           override: true
           target: ${{ matrix.settings.target }}
       - name: Generate Cargo.lock
         uses: actions-rs/cargo@v1
+        if: ${{ !matrix.settings.docker }}
         with:
           command: generate-lockfile
       - name: Cache cargo registry
         uses: actions/cache@v2
         with:
           path: ~/.cargo/registry
-          key: ${{ matrix.settings.target }}-node@16-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.settings.target }}-cargo-registry
       - name: Cache cargo index
         uses: actions/cache@v2
         with:
           path: ~/.cargo/git
-          key: ${{ matrix.settings.target }}-node@16-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.settings.target }}-cargo-index
       - name: Cache NPM dependencies
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: npm-cache-${{ matrix.settings.target }}-node@16-${{ hashFiles('yarn.lock') }}
-      - name: Pull latest image
-        run: ${{ matrix.settings.docker }}
-        env:
-          DOCKER_REGISTRY_URL: ghcr.io
-        if: ${{ matrix.settings.docker }}
+          key: npm-cache-build-${{ matrix.settings.target }}-node@16
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}
         if: ${{ matrix.settings.setup }}
         shell: bash
       - name: Install dependencies
         run: yarn install --ignore-scripts --frozen-lockfile --registry https://registry.npmjs.org --network-timeout 300000
+
+      - name: Build in docker
+        uses: addnab/docker-run-action@v3
+        if: ${{ matrix.settings.docker }}
+        with:
+          image: ${{ matrix.settings.docker }}
+          options: -v ${{ env.HOME }}/.cargo/git:/root/.cargo/git -v ${{ env.HOME }}/.cargo/registry:/root/.cargo/registry -v ${{ github.workspace }}:/build -w /build
+          run: ${{ matrix.settings.build }}
+
       - name: Build
         run: ${{ matrix.settings.build }}
+        if: ${{ !matrix.settings.docker }}
         shell: bash
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@napi-rs/canvas": "^0.1.19",
-    "@napi-rs/cli": "^2.3.0",
+    "@napi-rs/cli": "^2.4.2",
     "@swc-node/register": "^1.4.2",
     "@types/node": "^17.0.1",
     "@types/sharp": "^0.29.5",

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2021-12-23
+nightly

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,10 +473,10 @@
     "@napi-rs/canvas-linux-x64-musl" "0.1.19"
     "@napi-rs/canvas-win32-x64-msvc" "0.1.19"
 
-"@napi-rs/cli@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.3.0.tgz#fb3c9179bf2ff1088f19b235108208acaf051b6f"
-  integrity sha512-sDhyEuUVmgQvm37teoHgJP07+XJy57jfbnDBFVrgOw/+vbr/6yhcn68R3oYxxNLkp3+d57ChVyHxglEFJ6j4Hg==
+"@napi-rs/cli@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.4.2.tgz#89b32c7d8776004bc9617915605aea769339cf6f"
+  integrity sha512-+yCOuPqernvD8BMphbadF87ElaJ0rjanOZrbnauaEdR07YyoalGw3FTk15HHyflIwQKlYd69gkG5EM4WFkICKw==
 
 "@napi-rs/triples@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
Support for CentOS 7 (glibc 2.17) and CentOS 6 (glibc 2.12).

This PR is cross-compiled with zig, passing the `--zig --zig-abi-suffix 2.12` argument causes it to compile a statically linked binary.

On systems with glibc < 2.18, the error message will not appear: 

> Error: /lib64/libc.so.6: version `GLIBC_2.18' not found