### PR TITLE
chore: improved error message when output PNG size is 0

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ pub enum Error {
   USvg(#[from] usvg::Error),
   #[error(transparent)]
   Encoding(#[from] png::EncodingError),
-  #[error("Target size is zero")]
+  #[error("Target size is zero (please do not set the width/height/zoom options to 0)")]
   ZeroSized,
   #[error("Input must be string or Uint8Array")]
   InvalidInput,


### PR DESCRIPTION
In addition, tests for blank SVGs have been added, and starting with resvg 0.21.0 https://github.com/RazrFalcon/resvg/commit/5998e9b8411ff3f0171515371938ee1940be17c3 , blank SVGs will generate 100x100 transparent PNG.