### PR TITLE
feat: preload wasm in the playground

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -5,6 +5,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>resvg-js playground</title>
+  <link rel="preload" as="fetch" type="application/wasm" href="https://unpkg.com/@resvg/resvg-wasm/index_bg.wasm">
+  <script src="https://unpkg.com/@resvg/resvg-wasm@2.0.0-alpha.0/index.min.js"></script>
   <style>
     html {
       box-sizing: border-box;
@@ -128,8 +130,8 @@
       animation: octocat-wave 560ms ease-in-out;
     }
   </style>
-  <script src="https://unpkg.com/@resvg/resvg-wasm@2.0.0-alpha.0/index.min.js"></script>
-  <script>
+
+<script>
     (async function () {
       await resvg.initWasm(fetch('https://unpkg.com/@resvg/resvg-wasm/index_bg.wasm'))
       const output = document.getElementById('output')

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -5,6 +5,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>resvg-js playground</title>
+  <link rel="preload" as="fetch" type="application/wasm" href="https://unpkg.com/@resvg/resvg-wasm/index_bg.wasm">
+  <script src="https://unpkg.com/@resvg/resvg-wasm@2.0.0-alpha.0/index.min.js"></script>
   <style>
     html {
       box-sizing: border-box;
@@ -128,8 +130,8 @@
       animation: octocat-wave 560ms ease-in-out;
     }
   </style>
-  <script src="https://unpkg.com/@resvg/resvg-wasm@2.0.0-alpha.0/index.min.js"></script>
-  <script>
+
+<script>
     (async function () {
       await resvg.initWasm(fetch('https://unpkg.com/@resvg/resvg-wasm/index_bg.wasm'))
       const output = document.getElementById('output')


### PR DESCRIPTION
```html
<link rel="preload" as="fetch" type="application/wasm" href="https://unpkg.com/@resvg/resvg-wasm/index_bg.wasm">
```

In theory, this will make the page open and render slightly faster.

preload：https://resvg-js-git-preload-wasm-yisibl.vercel.app/
vs
old：https://resvg-js.vercel.app/