### PR TITLE
chore(deps): remove the unused chalk devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "@typescript-eslint/parser": "^5.3.1",
     "ava": "^3.15.0",
     "benny": "^3.7.1",
-    "chalk": "^4.1.2",
     "copyfiles": "^2.4.1",
     "dts-bundle-generator": "^6.5.0",
     "esbuild": "^0.14.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,7 +1202,7 @@ canvg@3.0.7:
     stackblur-canvas "^2.0.0"
     svg-pathdata "^5.0.5"
 
-chalk@4, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+chalk@4, chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.npmmirror.com/chalk/download/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=


### PR DESCRIPTION
AFAICT the direct chalk devDependency is not needed.