### PR TITLE
chore: add libc fields on linux platform packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This changelog also contains important changes in dependencies.
 
 ## [Unreleased]
 
+### Changed
+
+- chore: add libc fields on linux platform packages
+
+  On Linux, it is not possible to tell exactly what kind of C library a native modules depends on just by os/cpu, so yarn 3.2 and cnpm added libc fields to further distinguish this case. This avoids downloading both `gnu` and `musl` packages at the same time.
+
+  Currently only [yarn 3.2+](https://github.com/yarnpkg/berry/pull/3981) and [cnpm](https://github.com/cnpm/npminstall/pull/387) are supported, the npm implementation is [still under discussion](https://github.com/npm/rfcs/pull/519).
+
 ## [2.0.0-alpha.5] - 2022-03-19
 
 ### Changed

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -7,6 +7,9 @@
   "cpu": [
     "arm64"
   ],
+  "libc": [
+    "glibc"
+  ],
   "main": "resvgjs.linux-arm64-gnu.node",
   "files": [
     "resvgjs.linux-arm64-gnu.node"

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -7,6 +7,9 @@
   "cpu": [
     "arm64"
   ],
+  "libc": [
+    "musl"
+  ],
   "main": "resvgjs.linux-arm64-musl.node",
   "files": [
     "resvgjs.linux-arm64-musl.node"

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -7,6 +7,9 @@
   "cpu": [
     "x64"
   ],
+  "libc": [
+    "glibc"
+  ],
   "main": "resvgjs.linux-x64-gnu.node",
   "files": [
     "resvgjs.linux-x64-gnu.node"

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -7,6 +7,9 @@
   "cpu": [
     "x64"
   ],
+  "libc": [
+    "musl"
+  ],
   "main": "resvgjs.linux-x64-musl.node",
   "files": [
     "resvgjs.linux-x64-musl.node"


### PR DESCRIPTION
With this update, you can avoid downloading both `gnu` and `musl` packages in Linux, since you can't accurately determine the C libraries that native modules depend on just from `os/cpu`.

  Currently only [yarn 3.2+](https://github.com/yarnpkg/berry/pull/3981) and [cnpm](https://github.com/cnpm/npminstall/pull/387) are supported, the npm implementation is [still under discussion](https://github.com/npm/rfcs/pull/519).