### PR TITLE
build: fix i686-pc-windows-msvc error

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2022-04-20


### PR DESCRIPTION
```bash
yarn test
exited with a non-zero exit code: 3221225477
```

Even setting [`CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1024`](https://github.com/yisibl/resvg-js/commit/3bb6d3c4237d56f31a9a11c53456be8e5bf09de9) doesn't fix it, so we temporarily lock the rust-toolchain version to `nightly-2022-04-20`

Waiting for upstream solution: https://github.com/rust-lang/rust/issues/67497

See also https://github.com/napi-rs/napi-rs/issues/297

