### PR TITLE
fix(ci): use zig to cross-compile armv7

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,6 @@
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 
-[target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"
-
 [target.x86_64-unknown-linux-musl]
 rustflags = [
     "-C",

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -66,7 +66,7 @@ jobs:
               export CXX=$(xcrun -f clang++);
               SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
               export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
-              yarn build --target=aarch64-apple-darwin
+              yarn build --target aarch64-apple-darwin
               strip -x *.node
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
@@ -80,9 +80,9 @@ jobs:
             target: armv7-unknown-linux-gnueabihf
             setup: |
               sudo apt-get update
-              sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf -y
+              sudo apt-get install gcc-arm-linux-gnueabihf -y
             build: |
-              yarn build --target=armv7-unknown-linux-gnueabihf
+              yarn build --target armv7-unknown-linux-gnueabihf
               arm-linux-gnueabihf-strip *.node
           - host: ubuntu-latest
             target: aarch64-linux-android
@@ -152,11 +152,10 @@ jobs:
             .cargo-cache/git/db/
             target/
           key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
-      - name: Cache NPM dependencies
-        uses: actions/cache@v3
+      - uses: goto-bus-stop/setup-zig@v2
+        if: ${{ matrix.settings.target == 'armv7-unknown-linux-gnueabihf' }}
         with:
-          path: .yarn/cache
-          key: npm-cache-build-${{ matrix.settings.target }}-node@16
+          version: 0.10.0
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}
         if: ${{ matrix.settings.setup }}

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "@napi-rs/canvas": "^0.1.25",
-    "@napi-rs/cli": "^2.10.0",
+    "@napi-rs/cli": "^2.13.2",
     "@swc-node/register": "^1.5.1",
     "@types/node": "^18.0.0",
     "@types/sharp": "^0.31.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,12 +233,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/cli@npm:^2.10.0":
-  version: 2.10.1
-  resolution: "@napi-rs/cli@npm:2.10.1"
+"@napi-rs/cli@npm:^2.13.2":
+  version: 2.13.2
+  resolution: "@napi-rs/cli@npm:2.13.2"
   bin:
     napi: scripts/index.js
-  checksum: 2c3ee83577c45d1ba01934d5f8a7068a451877e230f6bbf5559a0c767aa4e0f626fe6511705dc9a1add43d75a8fa08e890dc620277aede27ddbbc0ba0d502b30
+  checksum: cf9b4d48031ff2981ceaac92afe3b17bc9e2af4e97ae414d469638280cb377f43bf60bd45ce974a756fc7ae7b33ba82c9fc26d0057cce5a028b3537a06824a58
   languageName: node
   linkType: hard
 
@@ -294,7 +294,7 @@ __metadata:
   resolution: "@resvg/resvg-js@workspace:."
   dependencies:
     "@napi-rs/canvas": ^0.1.25
-    "@napi-rs/cli": ^2.10.0
+    "@napi-rs/cli": ^2.13.2
     "@swc-node/register": ^1.5.1
     "@types/node": ^18.0.0
     "@types/sharp": ^0.31.0


### PR DESCRIPTION
Due to the GitHub Actions Ubuntu [upgrade from 20.04 to 22.04](https://github.com/actions/runner-images/issues/5490), the glibc version became 2.35. To maintain our compatibility, zig cross-compilation is now enabled to support older versions of glibc systems.

| Distribution | Glibc | GCC |
| --- | --- | --- |
| CentOS 7 | 2.17 | 4.8.5 |
| Ubuntu 16.04 | 2.23 | 5.4.0 |
| Ubuntu 18.04 | 2.27 | 7.5.0 |
| Ubuntu 20.04 | 2.31 | 9.4.0 |
| **Ubuntu 22.04** | 2.35 | 11.2.0 |
| Debian 10.12 | 2.28 | 8.3.0 |
| Debian 11.4 | 2.31 | 10.2.1 |

`@napi-rs/cli` supports cross-compiling to armv7 using zig in [@napi-rs/cli@2.13.1](https://github.com/napi-rs/napi-rs/releases/tag/%40napi-rs%2Fcli%402.13.1), so this dependency has been upgraded here as well.

This solves the problem of CI errors:

```shell
Error: /lib/arm-linux-gnueabihf/libm.so.6: version `GLIBC_2.35' not found (required by /build/resvgjs.linux-arm-gnueabihf.node)
```

