### PR TITLE
feat: add wasm file to exports

### DIFF
--- a/wasm/package.json
+++ b/wasm/package.json
@@ -10,7 +10,8 @@
     ".": {
       "import": "./index.mjs",
       "default": "./index.js"
-    }
+    },
+    "./index_bg.wasm": "./index_bg.wasm"
   },
   "files": [
     "index_bg.wasm",


### PR DESCRIPTION
require.resolve and bundlers like vite are unable to resolve the wasm file.

Cheers