### PR TITLE
fix: enable static link for windows-msvc

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,3 +10,6 @@ rustflags = [
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
 rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,3 +13,6 @@ rustflags = ["-C", "target-feature=-crt-static"]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2549,9 +2549,9 @@ __metadata:
   linkType: hard
 
 "ip@npm:^1.1.5":
-  version: 1.1.8
-  resolution: "ip@npm:1.1.8"
-  checksum: a2ade53eb339fb0cbe9e69a44caab10d6e3784662285eb5d2677117ee4facc33a64679051c35e0dfdb1a3983a51ce2f5d2cb36446d52e10d01881789b76e28fb
+  version: 1.1.9
+  resolution: "ip@npm:1.1.9"
+  checksum: b6d91fd45a856e3bd6d4f601ea0619d90f3517638f6918ebd079f959a8a6308568d8db5ef4fdf037e0d9cfdcf264f46833dfeea81ca31309cf0a7eb4b1307b84
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The generated `.node` file for Windows require certain DLLs which may not be present, especially in applications used by end-users which can lead to a `Missing DLL error.

It was my case with some users with my application so I've switch to `sharp` for now.

With [Dependencies](https://github.com/lucasg/Dependencies) we can see the amount of needed DLLs is greatly reduce with static link :
|before|after|
|--|--|
|![image](https://github.com/yisibl/resvg-js/assets/40181755/c3df36d1-abe6-4997-aae3-6d05fa0a2f47)|![image](https://github.com/yisibl/resvg-js/assets/40181755/9cc2dd4f-2c18-4861-8a4a-a4ac5d7a0849)|

The size of the generated `.node` file is a slightly larger tho
|before|after|
|--|--|
|4.12mo|4.29mo|

