### PR TITLE
Describe how to free memory in README and fix a memory leak in playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ This package also ships a pure WebAssembly artifact built with `wasm-bindgen` to
     const resvgJS = new resvg.Resvg(svg, opts)
     const pngData = resvgJS.render(svg, opts) // Output PNG data, Uint8Array
     const pngBuffer = pngData.asPng()
+    pngData.free() // Free memory
+    resvgJS.free()
     const svgURL = URL.createObjectURL(new Blob([pngData], { type: 'image/png' }))
     document.getElementById('output').src = svgURL
   })()

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -320,6 +320,9 @@
         const pngData = resvgJS.render()
         const pngBuffer = pngData.asPng()
 
+        pngData.free()
+        resvgJS.free()
+
         document.querySelector('#output img').src = URL.createObjectURL(
           new Blob([pngBuffer], { type: 'image/png' })
         )


### PR DESCRIPTION
ref: #216, https://github.com/orgs/vercel/discussions/6117

The wasm version needs to free memory manually. However, the README does not describe how to do this. Therefore, writing code based on the README will cause memory leaks. This confuses users.

- https://github.com/yisibl/resvg-js/issues/216#issuecomment-1994994730

This PR describes the procedure to free memory in the README.

In addition, I have fixed a memory leak in the playground.