### PR TITLE
fix(ci): missing `.node` file for x86_64-apple-darwin

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,7 +31,7 @@ jobs:
           - host: macos-14
             target: x86_64-apple-darwin
             build: |
-              yarn build
+              yarn build --target x86_64-apple-darwin
               strip -x *.node
           - host: windows-latest
             build: yarn build


### PR DESCRIPTION
We need to set a default target for `macos-14` when you build, otherwise, x86_64-apple-darwin will be packaged as an arm64 file, and the npm release will fail due to the lack of x86_64 files.

Problems introduced here: https://github.com/yisibl/resvg-js/commit/0cae91e1ac51c74a87c479280a27f75e5efd029d

Closed: https://github.com/yisibl/resvg-js/issues/319


See log: https://github.com/yisibl/resvg-js/actions/runs/8419314291/job/23051987833

![image](https://github.com/yisibl/resvg-js/assets/2784308/ce4025dd-2f3f-492e-a791-b135492bbaa6)
