### PR TITLE
feat(cli): add `resvg-js` CLI to @resvg/resvg-js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 js-binding.js
 js-binding.d.ts
 target
+/cli.js
 wasm
 wasm/dist

--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,7 @@ $RECYCLE.BIN/
 
 # End of https://www.toptal.com/developers/gitignore/api/windows
 
-#Added by cargo
+# Added by cargo
 
 /target
 Cargo.lock
@@ -195,3 +195,6 @@ Cargo.lock
 !.yarn/versions
 
 *.node
+
+# Added CLI bundle file
+/cli.js

--- a/bin/resvg-js
+++ b/bin/resvg-js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+'use strict'
+require('../cli.js')

--- a/bundle-prepublish.js
+++ b/bundle-prepublish.js
@@ -1,0 +1,20 @@
+// @ts-check
+const { buildSync } = require('esbuild')
+
+buildSync({
+  entryPoints: ['js-binding.js'],
+  allowOverwrite: true,
+  outfile: 'js-binding.js',
+  logLevel: 'info',
+  minify: true,
+})
+
+buildSync({
+  entryPoints: ['cli/cli.js'],
+  outfile: 'cli.js',
+  logLevel: 'info',
+  minify: false,
+  bundle: true,
+  platform: 'node',
+  external: ['./index'],
+})

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -40,24 +40,25 @@ async function bootsrap(argvs = process.argv) {
     /** @type {import ('../index.d').RenderedImage | null} */
     let fileData = null
     const { Resvg } = require('../index')
+    const { getBufferFromStdin, writeBufferToStdout } = require('./util')
     if (paths.input !== '-') {
       const { promises } = require('fs')
       const svgBuffer = await promises.readFile(paths.input)
       const resvg = new Resvg(svgBuffer, resvgOptions)
       fileData = resvg.render()
     } else {
-      const { getBufferFromStdin } = require('./util')
       const svgBuffer = await getBufferFromStdin()
       const resvg = new Resvg(svgBuffer, resvgOptions)
       fileData = resvg.render()
     }
 
     // Output
+    // TODO: wait for add more output formats, e.g. avif, webp, JPEG XL
+    const imageBuffer = fileData.asPng()
     if (paths.output && fileData) {
       const { promises } = require('fs')
       const { logger } = require('./util')
-      // TODO: wait for add more output formats, e.g. avif, webp, JPEG XL
-      await promises.writeFile(paths.output, fileData.asPng())
+      await promises.writeFile(paths.output, imageBuffer)
       switch (resvgOptions?.logLevel) {
         case 'off':
           break
@@ -69,7 +70,7 @@ async function bootsrap(argvs = process.argv) {
           break
       }
     } else {
-      process.stdout.write(fileData.asPng())
+      await writeBufferToStdout(imageBuffer)
     }
   }
 }

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -1,0 +1,84 @@
+const process = require('process')
+
+process.on('uncaughtException', (err) => {
+  console.error(err.message || err)
+  process.exit(1)
+})
+
+process.stdin.on('data', (key) => {
+  // ensure catch SIGINT signal like control+c
+  // eslint-disable-next-line eqeqeq
+  if (key == '\u0003') {
+    process.exit(130) // 128 + SIGINT
+  }
+})
+
+async function bootsrap(argvs = process.argv) {
+  const { version } = require('../package.json')
+
+  const minimist = require('minimist')
+  /** @type {import ('./help.d').CLIOptions & import('minimist').ParsedArgs} */
+  const parsedArgv = minimist(argvs.slice(2, argvs.length), {
+    alias: {
+      v: 'version',
+      h: 'help',
+    },
+  })
+
+  if (parsedArgv.version) {
+    // eslint-disable-next-line no-console
+    console.log(version)
+  } else if (parsedArgv.help) {
+    const { printHelp } = require('./help')
+    printHelp(version)
+  } else {
+    // Main
+    const { transformOptions } = require('./option')
+    const [paths, resvgOptions] = transformOptions(parsedArgv)
+
+    // Input
+    /** @type {import ('../index.d').RenderedImage | null} */
+    let fileData = null
+    const { Resvg } = require('../index')
+    if (paths.input !== '-') {
+      const { promises } = require('fs')
+      const svgBuffer = await promises.readFile(paths.input)
+      const resvg = new Resvg(svgBuffer, resvgOptions)
+      fileData = resvg.render()
+    } else {
+      const { getBufferFromStdin } = require('./util')
+      const svgBuffer = await getBufferFromStdin()
+      const resvg = new Resvg(svgBuffer, resvgOptions)
+      fileData = resvg.render()
+    }
+
+    // Output
+    if (paths.output && fileData) {
+      const { promises } = require('fs')
+      const { logger } = require('./util')
+      // TODO: wait for add more output formats, e.g. avif, webp, JPEG XL
+      await promises.writeFile(paths.output, fileData.asPng())
+      switch (resvgOptions?.logLevel) {
+        case 'off':
+          break
+        case 'info':
+          logger.info(paths.output, `{ width: ${fileData.width}, height: ${fileData.height} }`, 'image')
+          break
+        default:
+          logger.info(paths.output)
+          break
+      }
+    } else {
+      process.stdout.write(fileData.asPng())
+    }
+  }
+}
+
+bootsrap()
+  .then(() => {
+    process.exit(0)
+  })
+  .catch((err) => {
+    console.error(err.message || err)
+    process.exit(1)
+  })

--- a/cli/help.d.ts
+++ b/cli/help.d.ts
@@ -1,0 +1,30 @@
+import { ResvgRenderOptions } from '../index'
+
+export type CLIOptions = {
+  help?: boolean
+  version?: boolean
+  'system-font'?: boolean
+  'font-file'?: string | string[]
+  'font-dir'?: string | string[]
+  'font-default-size'?: number
+  'font-default-family'?: string
+  'font-serif-family'?: string
+  'font-sans-serif-family'?: string
+  'font-cursive-family'?: string
+  'font-fantasy-family'?: string
+  'font-monospace-family'?: string
+  'shape-rendering'?: 0 | 1 | 2
+  'text-rendering'?: 0 | 1 | 2
+  'image-rendering'?: 0 | 1
+  'fit-width'?: number
+  'fit-height'?: number
+  'fit-zoom'?: number
+  'crop-top'?: number
+  'crop-left'?: number
+  'crop-right'?: number
+  'crop-bottom'?: number
+  dpi?: number
+  language?: string | string[]
+  background?: string
+  'log-level'?: ResvgRenderOptions['logLevel']
+}

--- a/cli/help.js
+++ b/cli/help.js
@@ -1,0 +1,75 @@
+/* eslint-disable no-console */
+/* prettier-ignore */
+
+/**
+ * @param {string} version
+ */
+module.exports.printHelp = function printHelp(version) {
+  const { pc } = require('./style')
+
+  console.log(
+    `${pc.yellow('NAME:')}
+    ${pc.green('resvg-js')} - A high-performance SVG renderer CLI, powered by Rust based resvg and napi-rs
+
+${pc.yellow('WEBSITE:')}
+    ${pc.underline('https://github.com/yisibl/resvg-js')}
+
+${pc.yellow('VERSION:')} ${version}
+
+${pc.yellow('SYNOPSIS:')}
+    resvg-js [OPTIONS] <input_svg_path | '-'> [output_path]
+
+${pc.yellow('OPTIONS:')}
+  ${pc.gray('Font:')}
+    ${pc.cyan('--no-system-font')}                ${pc.red('Unuse system font, it will be faster')}
+    ${pc.cyan('--font-file        <file_path>')}  ${pc.red('Local font file path')}   ${pc.gray('[Mutilple]')}
+    ${pc.cyan('--font-dir          <dir_path>')}  ${pc.red('Local font directories')} ${pc.gray('[Mutilple]')}
+    ${pc.cyan('--font-default-size      <num>')}  ${pc.red('Default font size')}      ${pc.gray('[Default: 12]')}
+    ${pc.cyan('--font-default-family    <str>')}  ${pc.red('The default font family')}
+    ${pc.cyan('--font-serif-family      <str>')}  ${pc.red('The serif font family')}
+    ${pc.cyan('--font-sans-serif-family <str>')}  ${pc.red('The sans-serif font family')}
+    ${pc.cyan('--font-cursive-family    <str>')}  ${pc.red('The cursive font family')}
+    ${pc.cyan('--font-fantasy-family    <str>')}  ${pc.red('The fantasy font family')}
+    ${pc.cyan('--font-monospace-family  <str>')}  ${pc.red('The monospace font family')}
+
+  ${pc.gray('Rendering Optimize:')}
+    ${pc.cyan('--shape-rendering <0|1|2>')}       ${pc.red('Shape rendering optimize rule')}
+        ${pc.gray('[0: optimizeSpeed, 1: crispEdges, 2: geometricPrecision]')}
+    ${pc.cyan('--text-rendering  <0|1|2>')}       ${pc.red('Text rendering optimize rule')}
+        ${pc.gray('[0: optimizeSpeed, 1: optimizeLegibility, 2: geometricPrecision]')}
+    ${pc.cyan('--image-rendering <0|1>')}         ${pc.red('Image rendering optimize rule')}
+        ${pc.gray('[0: optimizeQuality, 1: optimizeSpeed]')}
+
+  ${pc.gray('Fit To (default use original):')}
+    ${pc.cyan('--fit-width   <num>')}             ${pc.red('Use fit to width mode')}
+    ${pc.cyan('--fit-height  <num>')}             ${pc.red('Use fit to height mode')}
+    ${pc.cyan('--fit-zoom    <num>')}             ${pc.red('Use fit to zoom mode')}
+
+  ${pc.gray('Crop:')}
+    ${pc.cyan('--crop-top    <num>')}             ${pc.red('Crop image top size')}
+    ${pc.cyan('--crop-left   <num>')}             ${pc.red('Crop image left size')}
+    ${pc.cyan('--crop-right  <num>')}             ${pc.red('Crop image right size')}
+    ${pc.cyan('--crop-bottom <num>')}             ${pc.red('Crop image bottom size')}
+
+    ${pc.cyan('--dpi        <num>')}              ${pc.red('Dots Per Inch')}
+    ${pc.cyan('--language   <lang>')}             ${pc.red('Language code')} ${pc.gray('[Mutilple]')}
+    ${pc.cyan('--background <CSS3_color>')}       ${pc.red('Background color')}
+    ${pc.cyan('--log-level  <logLevel>')}         ${pc.red('Setting log level')}
+
+${pc.yellow('ARGS:')}
+    ${pc.cyan('<input_file_path>')}               ${pc.red('SVG file path. Use "-" for stdin')}
+    ${pc.cyan('[output_file_path]')}              ${pc.red('Output image file path')}
+
+${pc.yellow('EXAMPLES:')}
+    ${pc.cyan('resvg-js input.svg output.png')}
+    ${pc.cyan('resvg-js --fit-width 1200 input.svg output.png')}
+    ${pc.cyan(`resvg-js \\
+        --no-system-font                    \\
+        --font-file "./Font-Light.ttf"      \\
+        --font-file "./Font-Bold.ttf"       \\
+        --font-default-family "Font"        \\
+        --background "rgba(238,235,230,.9)" \\
+        ./input.svg ./output.png`)}
+    ${pc.cyan('cat a.svg | resvg-js --fit-width 1200 --image-rending 0 - output.png')}
+`)
+}

--- a/cli/option.js
+++ b/cli/option.js
@@ -1,0 +1,97 @@
+/** Allow partial options using Camel-Case */
+const optionMapping = {
+  // font
+  'system-font': 'loadSystemFonts',
+  'font-file': 'fontFiles',
+  'font-dir': 'fontDirs',
+  'font-default-size': 'defaultFontSize',
+  'font-default-family': 'defaultFontFamily',
+  'font-serif-family': 'serifFamily',
+  'font-sans-serif-family': 'sansSerifFamily',
+  'font-cursive-family': 'cursiveFamily',
+  'font-fantasy-family': 'fantasyFamily',
+  'font-monospace-family': 'monospaceFamily',
+  // rendering
+  'shape-rendering': 'shapeRendering',
+  shapeRendering: 'shapeRendering',
+  'text-rendering': 'textRendering',
+  textRendering: 'textRendering',
+  'image-rendering': 'imageRendering',
+  imageRendering: 'imageRendering',
+  // crop
+  'crop-top': 'top',
+  'crop-left': 'left',
+  'crop-right': 'right',
+  'crop-bottom': 'bottom',
+  // other
+  dpi: 'dpi',
+  language: 'languages',
+  background: 'background',
+  'log-level': 'logLevel',
+}
+
+/**
+ * transform argv to ResvgRenderOptions
+ *
+ * @param {import ('./help.d').CLIOptions & import('minimist').ParsedArgs} parseArgv
+ * @return {[
+ *    { input: string, output?: string },
+ *    import('../index').ResvgRenderOptions
+ *  ]}
+ */
+module.exports.transformOptions = function transformOptions(parseArgv) {
+  const { getPathsByArgs, logger, unkonwOptionExit } = require('./util')
+  // #region - Args to Paths
+  const [tmpInput, tmpOutput] = parseArgv._
+  const result = [getPathsByArgs(tmpInput, tmpOutput)]
+  if (parseArgv?.['log-level'] === 'debug') {
+    logger.info('Argv', JSON.stringify(parseArgv), 'JSON')
+    logger.info('Input and Output Path', JSON.stringify(result[0]), 'JSON')
+  }
+  delete parseArgv._
+  // #endregion
+
+  // #region - Main Options
+  const options = {}
+  for (const key in parseArgv) {
+    // handle fit-*
+    if (key.startsWith('fit-')) {
+      options['fitTo'] = {
+        mode: key.slice(4),
+        value: parseArgv[key],
+      }
+      continue
+    }
+
+    // format mutilple string
+    if (['font-file', 'font-dir', 'language'].includes(key) && typeof parseArgv[key] === 'string') {
+      parseArgv[key] = [parseArgv[key]]
+    }
+    // format path option
+    if (['font-file', 'font-dir'].includes(key)) {
+      const { resolve } = require('path')
+      parseArgv[key] = Array.isArray(parseArgv[key])
+        ? parseArgv[key].map((path) => resolve(process.cwd(), path))
+        : resolve(process.cwd(), parseArgv[key])
+    }
+
+    // other option using mapping
+    !(key in optionMapping) && unkonwOptionExit(key)
+    if (key.startsWith('font-') || key === 'system-font') {
+      options['font'] ??= {}
+      options['font'][optionMapping[key]] = parseArgv[key]
+    } else if (key.startsWith('crop-')) {
+      options['crop'] ??= {}
+      options['crop'][optionMapping[key]] = parseArgv[key]
+    } else {
+      options[optionMapping[key]] = parseArgv[key]
+    }
+  }
+  // #endregion
+  result.push(options)
+
+  if (parseArgv?.['log-level'] === 'debug') {
+    logger.info('Options', JSON.stringify(result[1]), 'JSON')
+  }
+  return result
+}

--- a/cli/style.js
+++ b/cli/style.js
@@ -1,0 +1,104 @@
+/**
+ * Terminal style output colorizen
+ * Inspiring picocolors(https://www.npmjs.com/package/picocolors)
+ */
+const process = require('process')
+const tty = require('tty')
+
+/**
+ * Check current is support color command text
+ * @param colorSupoort can force output not colorizen
+ */
+function isColorizenSupport(colorSupoort = true) {
+  return (
+    (colorSupoort &&
+      !('NO_COLOR' in process.env) &&
+      (process.platform === 'win32' || (tty.isatty(1) && process.env.TERM !== 'dumb') || 'CI' in process.env)) ||
+    'FORCE_COLOR' in process.env
+  )
+}
+
+/**
+ * Provide to formatter. If has close tag, replace it
+ *
+ * @param {string} str
+ * @param {string} close
+ * @param {string} replace
+ * @param {number} index
+ * @return {string}
+ */
+function replaceClose(str, close, replace, index) {
+  const start = str.substring(0, index) + replace
+  const end = str.substring(index + close.length)
+  const nextIndex = end.indexOf(close)
+  return ~nextIndex ? start + replaceClose(end, close, replace, nextIndex) : start + end
+}
+
+/**
+ * A utils Fn provide to styleFn add asnii code
+ *
+ * @param {string} open
+ * @param {string} close
+ * @param {string} replace
+ * @return {(input: string) => string}
+ */
+function formatter(open, close, replace = open) {
+  return (input) => {
+    const string = `${input}`
+    const index = string.indexOf(close, open.length)
+    return ~index ? open + replaceClose(string, close, replace, index) + close : open + string + close
+  }
+}
+
+function styleFn(enabled = isColorizenSupport()) {
+  const init = enabled ? formatter : () => String
+  return {
+    isColorSupported: enabled,
+    reset: init('\x1B[0m', '\x1B[0m'),
+    bold: init('\x1B[1m', '\x1B[22m', '\x1B[22m\x1B[1m'),
+    dim: init('\x1B[2m', '\x1B[22m', '\x1B[22m\x1B[2m'),
+    italic: init('\x1B[3m', '\x1B[23m'),
+    underline: init('\x1B[4m', '\x1B[24m'),
+    inverse: init('\x1B[7m', '\x1B[27m'),
+    hidden: init('\x1B[8m', '\x1B[28m'),
+    strikethrough: init('\x1B[9m', '\x1B[29m'),
+
+    black: init('\x1B[30m', '\x1B[39m'),
+    red: init('\x1B[31m', '\x1B[39m'),
+    green: init('\x1B[32m', '\x1B[39m'),
+    yellow: init('\x1B[33m', '\x1B[39m'),
+    blue: init('\x1B[34m', '\x1B[39m'),
+    magenta: init('\x1B[35m', '\x1B[39m'),
+    cyan: init('\x1B[36m', '\x1B[39m'),
+    white: init('\x1B[37m', '\x1B[39m'),
+    gray: init('\x1B[90m', '\x1B[39m'),
+
+    bgBlack: init('\x1B[40m', '\x1B[49m'),
+    bgRed: init('\x1B[41m', '\x1B[49m'),
+    bgGreen: init('\x1B[42m', '\x1B[49m'),
+    bgYellow: init('\x1B[43m', '\x1B[49m'),
+    bgBlue: init('\x1B[44m', '\x1B[49m'),
+    bgMagenta: init('\x1B[45m', '\x1B[49m'),
+    bgCyan: init('\x1B[46m', '\x1B[49m'),
+    bgWhite: init('\x1B[47m', '\x1B[49m'),
+
+    rgb: (rgbColor = '38;5;036') => init(`\x1B[${rgbColor}m`, '\x1B[0m'),
+  }
+}
+
+/**
+ * support control isColorizen as param
+ * styleFn generator
+ *
+ * @param {boolen} enabled
+ * @return {Function} style
+ */
+module.exports.createStyle = styleFn
+
+/**
+ * commandline style output colorizen
+ *
+ * Automatically determine whether output coloring is required
+ * @tip the rgb color see to check your number: https://github.com/sindresorhus/xterm-colors
+ */
+module.exports.pc = styleFn()

--- a/cli/util.js
+++ b/cli/util.js
@@ -1,0 +1,74 @@
+const process = require('process')
+
+function createLogger() {
+  const { createStyle } = require('./style')
+  const pc = createStyle()
+  const { ___X_CMD_THEME_COLOR_CODE } = process.env
+  const pcInf = ___X_CMD_THEME_COLOR_CODE ? pc.rgb(___X_CMD_THEME_COLOR_CODE) : pc.green
+  return {
+    info: (msg, extraInfo, extraName = 'help') => {
+      process.stderr.write(`- ${pcInf('I|resvg-js')}: ${msg}\n`)
+      !!extraInfo && process.stderr.write(`  ${pcInf(extraName + ':')} ${extraInfo}\n`)
+    },
+    warn: (msg, extraInfo, extraName = 'help') => {
+      process.stderr.write(`${pc.yellow('-' + ' ' + pc.bold(pc.inverse('W') + '|resvg-js: ' + msg))}\n`)
+      !!extraInfo && process.stderr.write(`  ${pc.yellow(extraName + ':')} ${extraInfo}\n`)
+    },
+    error: (msg, extraInfo, extraName = 'help') => {
+      process.stderr.write(`${pc.red('-' + ' ' + pc.bold(pc.inverse('E') + '|resvg-js: ' + msg))}\n`)
+      !!extraInfo && process.stderr.write(`  ${pc.red(extraName + ':')} ${extraInfo}\n`)
+    },
+  }
+}
+module.exports.createLogger = createLogger
+
+const logger = createLogger()
+module.exports.logger = logger
+
+/**
+ * Exit directly and prompt for unknown options
+ * @param {string} command_options_key
+ */
+module.exports.unkonwOptionExit = function unkonwOptionExit(key) {
+  logger.error(`Unkonw option ==> --${key}`, 'Show more detail `--log-level debug`, or show help `resvg-js --help`')
+  process.exit(1)
+}
+
+/**
+ * Get the input and output paths
+ * @param {string} tmpInput
+ * @param {string|undefined} tmpOutput
+ */
+module.exports.getPathsByArgs = function getPathsByArgs(tmpInput, tmpOutput) {
+  if (!tmpInput) {
+    logger.error('Please provide an input file path', 'resvg-js [OPTIONS] <input_svg_path|"-"> [output_png_path]')
+    process.exit(1)
+  }
+  const base = process.cwd()
+  const { resolve } = require('path')
+  const { existsSync } = require('fs')
+  const input = tmpInput === '-' ? tmpInput : resolve(base, tmpInput)
+  if (input !== '-' && !existsSync(input)) {
+    logger.error('Input file not found. please check file exsit.', `=> ${input}`)
+    process.exit(1)
+  }
+
+  if (tmpOutput) {
+    const output = resolve(base, tmpOutput)
+    return { input, output }
+  } else {
+    return { input }
+  }
+}
+
+module.exports.getBufferFromStdin = async function () {
+  return new Promise((resolve, reject) => {
+    const chunks = []
+    process.stdin.on('data', (chunk) => chunks.push(chunk))
+    process.stdin.on('error', (err) => reject(err))
+    process.stdin.on('end', () => {
+      const buffer = Buffer.concat(chunks)
+      resolve(buffer)
+    })
+  })
+}

--- a/cli/util.js
+++ b/cli/util.js
@@ -72,3 +72,24 @@ module.exports.getBufferFromStdin = async function () {
     })
   })
 }
+
+module.exports.writeBufferToStdout = async function (buffer) {
+  return new Promise((resolve) => {
+    const stream = require('stream')
+    const rawStream = new stream.Readable({
+      read: function () {
+        if (buffer.length === 0) {
+          this.push(null)
+          resolve()
+        } else {
+          const chunkSize = 1024 // 1KB
+          const chunk = buffer.subarray(0, chunkSize)
+          buffer = buffer.subarray(chunkSize)
+          this.push(chunk)
+        }
+      },
+    })
+
+    rawStream.pipe(process.stdout)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -14,9 +14,13 @@
     "rust",
     "svg2png",
     "svg2img",
+    "CLI",
     "svg to png"
   ],
+  "bin": "bin/resvg-js",
   "files": [
+    "bin",
+    "cli.js",
     "index.d.ts",
     "index.js",
     "js-binding.js",
@@ -48,6 +52,7 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
+    "dev:cli": "esbuild ./cli/cli.js --outfile=./cli.js --bundle --external:./index --platform=node --watch",
     "bench": "node -r @swc-node/register benchmark/bench.ts",
     "bundle": "run-p 'bundle:*'",
     "bundle:js": "node bundle.js",
@@ -67,7 +72,7 @@
     "format:yaml": "prettier --parser yaml --write './**/*.{yml,yaml}'",
     "lint": "eslint . -c ./.eslintrc.yml './**/*.{ts,tsx,js}'",
     "lint:fix": "eslint . -c ./.eslintrc.yml './**/*.{ts,tsx,js}' --fix",
-    "prepublishOnly": "napi prepublish -t npm && esbuild js-binding.js --minify --allow-overwrite --outfile=js-binding.js",
+    "prepublishOnly": "napi prepublish -t npm && node bundle-prepublish.js",
     "test": "ava __test__/**/index*.*",
     "test:wasm": "ava __test__/**/wasm*.*",
     "version": "napi version"
@@ -91,6 +96,7 @@
     "husky": "^8.0.0",
     "jimp-compact": "^0.16.1-2",
     "lint-staged": "^15.0.0",
+    "minimist": "^1.2.8",
     "node-fetch": "2.x",
     "npm-run-all2": "^6.1.2",
     "prettier": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,10 +339,13 @@ __metadata:
     husky: ^8.0.0
     jimp-compact: ^0.16.1-2
     lint-staged: ^15.0.0
+    minimist: ^1.2.8
     node-fetch: 2.x
     npm-run-all2: ^6.1.2
     prettier: ^2.7.1
     typescript: ^5.4.2
+  bin:
+    resvg-js: bin/resvg-js
   languageName: unknown
   linkType: soft
 
@@ -3065,6 +3068,13 @@ __metadata:
   version: 1.2.6
   resolution: "minimist@npm:1.2.6"
   checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
+  languageName: node
+  linkType: hard
+
+"minimist@npm:^1.2.8":
+  version: 1.2.8
+  resolution: "minimist@npm:1.2.8"
+  checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#348 

I'm glad you can let me feel free do this work. 

After some consideration, I think it would be more straightforward to directly include the CLI bundle file in the @resvg/resvg-js project and add a bin file. This way, users can directly use the core functions in ./index.js with the transform options:
1. The CLI bundle file size is 28KB. View [npm:publish-code](https://www.npmjs.com/package/@qbbsh/resvg-js?activeTab=code).
2. After downloading @resvg/resvg-js, users can directly call the CLI in their projects using `yarn resvg-js` or `pnpm resvg-js`.

If you have any other ideas, feel free to tell me. 
monorepo or create a new repo. IMO, placing it in the project as a separate file that can be called will not disrupt the main program's operation, and it will maintain uniformity in future maintenance and version control.

---
Next plan:
- [ ] `js` or `ts` (I would like to hear your opinion. Initially, I found that index.js was written in JavaScript, but later the wasm was written in TypeScript.🫣)
- [ ] Add test for `cli/option.js`. ensure CLI options can be transform `ResvgOptions`
- [ ] README add usage
---

I released a pre-release version for testing, welcome to experience it

```sh
bunx @qbbsh/resvg-js -h
# or
npx @qbbsh/resvg-js -h
```

## Base usage

https://github.com/user-attachments/assets/b090f1a1-119a-4db2-b342-538765f5aefc

## Advanced Usage `pipeline`

> Use `imagemagick` to convert directly to webp format via pipeline. It can be used with other CLI tools for image cropping, conversion, editing ...

```sh
curl https://raw.githubusercontent.com/yisibl/resvg-js/main/example/text.svg | \
    npx @qbbsh/resvg-js --background "#fff" - | \
    magick  - webp:output.webp

magick output.webp -verbose info: | head
```

https://github.com/user-attachments/assets/7b19e954-a609-4763-a022-462f9f1143a5





